### PR TITLE
🔧修复：现在主页中的总使用时长和所有应用使用时长之和应该大致相等

### DIFF
--- a/SystemHelper.cs
+++ b/SystemHelper.cs
@@ -301,7 +301,7 @@ internal class ReminderHelper
 				logError = "在发送 总使用时间提醒通知 时触发异常：";
 				title = Loader.GetString("UsedTimeReminderTitle");
 				content = Loader.GetString("TotalReminderText1") +
-					WindowTracker.GetLocalTime(WindowTracker.TotalUsedTime) +
+					WindowTracker.GetLocalTime(TimeSpan.Zero, true) +
 					Loader.GetString("TotalReminderText2");
 				audio.Src = new(CommonSounds[(string) LocalSettings["TotalUsedTimeSound"]]);
 				break;

--- a/app.manifest
+++ b/app.manifest
@@ -17,11 +17,11 @@
 	</windowsSettings>
   </application>
 
-	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+	<!--<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>
 			<requestedPrivileges>
 				<requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
 			</requestedPrivileges>
 		</security>
-	</trustInfo>
+	</trustInfo>-->
 </assembly>


### PR DESCRIPTION
# 逻辑

新增了一个私密字段 `_totalUsedTime` 用于触发提醒，通过自增 1 秒来计数，目前认为是误差来源点。在修改公开属性 `TotalUsedTime` 的时候会同时修改私密字段 `_totalUsedTime` 。

# 显示

在提醒通知中显示私密字段 `_totalUsedTime` ，在主页及其他地方显示公开属性 `TotalUsedTime` 。