### PR TITLE
🔧修复：启动时发出的“总使用时长提醒”显示使用 <1 分

### DIFF
--- a/WindowTracker.cs
+++ b/WindowTracker.cs
@@ -191,12 +191,6 @@ internal class WindowTracker
 		}
 		else
 		{
-			if (HasTotalReminded)
-			{
-				// 如果已经达到了今日使用时长，则每次启动都提醒。
-				CanSend = ReminderHelper.SendReminder(ReminderKinds.TotalUsedTimeReminders);
-			}
-
 			// 获取记录的使用时长。
 			_totalUsedTime = TotalUsedTime;
 			try
@@ -231,6 +225,12 @@ internal class WindowTracker
 				CanSend = ReminderHelper.SendReminder("提示用户无法获取今天的记录",
 					Loader.GetString("ErrorOrWarningTitle"),
 					Loader.GetString("ECanNotGetRecord"), true);
+			}
+
+			if (HasTotalReminded)
+			{
+				// 如果已经达到了今日使用时长，则每次启动都提醒。
+				CanSend = ReminderHelper.SendReminder(ReminderKinds.TotalUsedTimeReminders);
 			}
 		}
 


### PR DESCRIPTION
将显示“总使用时长提醒”的逻辑放在获取总使用时长之后以保证显示的是正确的值。