### PR TITLE
🔧修复：图标可能过小或偏移

### DIFF
--- a/SystemHelper.cs
+++ b/SystemHelper.cs
@@ -258,6 +258,17 @@ internal static class SystemHelper
 	}
 
 	/// <summary>
+	/// 舍入 <paramref name="value"/> 为 <see langword="uint"/> 整数。遵循一般的四舍五入规则。当 <paramref name="value"/> 的小数部分为 0.5 时，向下舍入。
+	/// </summary>
+	/// <param name="value">要操作的 <see langword="double"/> 值。</param>
+	/// <returns>舍入后的 <see langword="uint"/> 整数。</returns>
+	public static uint Round(double value)
+	{
+		uint intValue = (uint) value;
+		return (value - intValue) < 0.5 ? intValue : intValue - 1;
+	}
+
+	/// <summary>
 	/// 将创建指定窗口的线程引入前台并激活窗口。键盘输入将定向到窗口，并为用户更改各种视觉提示。
 	/// </summary>
 	/// <param name="hWnd">应激活并带到前台的窗口的句柄。</param>

--- a/WindowTracker.cs
+++ b/WindowTracker.cs
@@ -585,29 +585,10 @@ internal class WindowTracker
 					goto Finish;
 				}
 
-				//IReadOnlyList<AppListEntry> appListEntries = await package.GetAppListEntriesAsync();
-				//AppListEntry appListEntry = appListEntries.Count > 0 ? appListEntries[0] : null;
-				//if (appListEntries == null)
-				//{
-				//	WriteLog(LogLevel.Warning, $"出于未知原因，未获取到包 {name} 的显示信息。");
-				//	info = GetDefaultInfo(process);
-				//	goto Finish;
-				//}
-
-				//AppDisplayInfo displayinfo = appListEntry.DisplayInfo;
-				//RandomAccessStreamReference iconStreamRef = displayinfo.GetLogo(new(32, 32));
-				//if (iconStreamRef == null)
-				//{
-				//	WriteLog(LogLevel.Warning, $"出于未知原因，未获取到包 {name} 的图标。");
-				//	info = GetDefaultInfo(process);
-				//	goto Finish;
-				//}
-
 				// 加载图标并将图标保存到缓存文件夹中。
 				string iconUri;
 				try
 				{
-					//IRandomAccessStreamWithContentType iconStream = await iconStreamRef.OpenReadAsync();
 					string iconPath = package.Logo.LocalPath;
 					StorageFile iconFile1 = await StorageFile.GetFileFromPathAsync(iconPath);
 					IRandomAccessStreamWithContentType iconStream = await iconFile1.OpenReadAsync();
@@ -676,53 +657,17 @@ internal class WindowTracker
 						}
 					}
 
-					//for (uint i = 0; i < height; i++)
-					//{
-					//	for (uint j = 0; j < width; j++)
-					//	{
-					//		if (pixels[(i * width + j) * 4 + 3] > 0)
-					//		{
-					//			if (x == 0 || i < x)
-					//			{
-					//				x = i;
-					//			}
-					//			if (y == 0 || j < y)
-					//			{
-					//				y = j;
-					//			}
-					//			if (w == 0 || i > w)
-					//			{
-					//				w = i;
-					//			}
-					//			if (h == 0 || j > h)
-					//			{
-					//				h = j;
-					//			}
-					//		}
-					//	}
-					//}
-
 					uint cropWidth = maxX - minX + 1, cropHeight = maxY - minY + 1;
 
-					// 图标实际内容的宽和高至少为 32 像素，且裁剪区域坐标不能为负。
+					// 图标裁剪区域至少为 32 * 32 像素，且裁剪区域坐标不能为负。
 					if (cropWidth < 32 && cropHeight < 32)
 					{
 						cropWidth = cropHeight = 32;
-						minX = SystemHelper.Round((width - cropWidth) / 2);//(uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
-						minY = SystemHelper.Round((width - cropHeight) / 2);//(uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
+						minX = SystemHelper.Round((width - cropWidth) / 2);
+						minY = SystemHelper.Round((width - cropHeight) / 2);
 					}
 					minX = minX < 0 ? 0 : minX;
 					minY = minY < 0 ? 0 : minY;
-					//else if (cropWidth > cropHeight)
-					//{
-					//	cropHeight = cropWidth;
-					//	y = SystemHelper.Round((width - cropHeight) / 2);//(uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
-					//}
-					//else if (cropHeight > cropWidth)
-					//{
-					//	cropWidth = cropHeight;
-					//	x = SystemHelper.Round((width - cropWidth) / 2);//(uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
-					//}
 
 					//裁剪图标。
 					InMemoryRandomAccessStream croppedStream = new();

--- a/WindowTracker.cs
+++ b/WindowTracker.cs
@@ -646,18 +646,18 @@ internal class WindowTracker
 					if (cropWidth < 32 || cropHeight < 32)
 					{
 						cropWidth = cropHeight = 32;
-						x = (uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
-						y = (uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
+						x = SystemHelper.Round((width - cropWidth) / 2);//(uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
+						y = SystemHelper.Round((width - cropHeight) / 2);//(uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
 					}
 					else if (cropWidth > cropHeight)
 					{
 						cropHeight = cropWidth;
-						y = (uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
+						y = SystemHelper.Round((width - cropHeight) / 2);//(uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
 					}
 					else if (cropHeight > cropWidth)
 					{
 						cropWidth = cropHeight;
-						x = (uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
+						x = SystemHelper.Round((width - cropWidth) / 2);//(uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
 					}
 					x = x < 0 ? 0 : x;
 					y = y < 0 ? 0 : y;

--- a/WindowTracker.cs
+++ b/WindowTracker.cs
@@ -641,7 +641,7 @@ internal class WindowTracker
 						}
 					}
 
-					// 图标实际内容的宽和高至少为 32 像素且必须是正方形。
+					// 图标实际内容的宽和高至少为 32 像素。
 					uint cropWidth = w - x + 1, cropHeight = h - y + 1;
 					if (cropWidth < 32 || cropHeight < 32)
 					{
@@ -649,16 +649,16 @@ internal class WindowTracker
 						x = SystemHelper.Round((width - cropWidth) / 2);//(uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
 						y = SystemHelper.Round((width - cropHeight) / 2);//(uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
 					}
-					else if (cropWidth > cropHeight)
-					{
-						cropHeight = cropWidth;
-						y = SystemHelper.Round((width - cropHeight) / 2);//(uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
-					}
-					else if (cropHeight > cropWidth)
-					{
-						cropWidth = cropHeight;
-						x = SystemHelper.Round((width - cropWidth) / 2);//(uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
-					}
+					//else if (cropWidth > cropHeight)
+					//{
+					//	cropHeight = cropWidth;
+					//	y = SystemHelper.Round((width - cropHeight) / 2);//(uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
+					//}
+					//else if (cropHeight > cropWidth)
+					//{
+					//	cropWidth = cropHeight;
+					//	x = SystemHelper.Round((width - cropWidth) / 2);//(uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
+					//}
 					x = x < 0 ? 0 : x;
 					y = y < 0 ? 0 : y;
 

--- a/WindowTracker.cs
+++ b/WindowTracker.cs
@@ -702,14 +702,17 @@ internal class WindowTracker
 					//	}
 					//}
 
-					// 图标实际内容的宽和高至少为 32 像素。
 					uint cropWidth = maxX - minX + 1, cropHeight = maxY - minY + 1;
-					if (cropWidth < 32 || cropHeight < 32)
+
+					// 图标实际内容的宽和高至少为 32 像素，且裁剪区域坐标不能为负。
+					if (cropWidth < 32 && cropHeight < 32)
 					{
 						cropWidth = cropHeight = 32;
 						minX = SystemHelper.Round((width - cropWidth) / 2);//(uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
 						minY = SystemHelper.Round((width - cropHeight) / 2);//(uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
 					}
+					minX = minX < 0 ? 0 : minX;
+					minY = minY < 0 ? 0 : minY;
 					//else if (cropWidth > cropHeight)
 					//{
 					//	cropHeight = cropWidth;
@@ -720,8 +723,6 @@ internal class WindowTracker
 					//	cropWidth = cropHeight;
 					//	x = SystemHelper.Round((width - cropWidth) / 2);//(uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
 					//}
-					minX = minX < 0 ? 0 : minX;
-					minY = minY < 0 ? 0 : minY;
 
 					//裁剪图标。
 					InMemoryRandomAccessStream croppedStream = new();

--- a/WindowTracker.cs
+++ b/WindowTracker.cs
@@ -646,18 +646,18 @@ internal class WindowTracker
 					if (cropWidth < 32 || cropHeight < 32)
 					{
 						cropWidth = cropHeight = 32;
-						x = (width - cropWidth) / 2;
-						y = (height - cropHeight) / 2;
+						x = (uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
+						y = (uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
 					}
 					else if (cropWidth > cropHeight)
 					{
 						cropHeight = cropWidth;
-						y = (height - cropHeight) / 2;
+						y = (uint) Math.Round((double) (height - cropHeight) / 2, MidpointRounding.AwayFromZero);
 					}
 					else if (cropHeight > cropWidth)
 					{
 						cropWidth = cropHeight;
-						x = (width - cropWidth) / 2;
+						x = (uint) Math.Round((double) (width - cropWidth) / 2, MidpointRounding.AwayFromZero);
 					}
 					x = x < 0 ? 0 : x;
 					y = y < 0 ? 0 : y;


### PR DESCRIPTION
1. 重新改用 `Package.Logo` 作为图标，理论上有微小的性能提升；
2.  更换了识别图标透明区域的算法，理论上有微小的性能提升；
3. 删除了强制图标为正方形的逻辑，保证不会因此产生意外的情况。