### PR TITLE
🔧修复：“查看所有应用”按钮没有正确显示

### DIFF
--- a/HomePage.xaml.cs
+++ b/HomePage.xaml.cs
@@ -24,29 +24,31 @@ namespace Zscno.Trackora
 
 		public async Task Refresh()
 		{
-			ProcessesList.ItemsSource = null;
 			LoadingRing.IsActive = true;
+
 			TotalUsedTime.Text = WindowTracker.GetLocalTime(WindowTracker.TotalUsedTime);
 			All.Content = Loader.GetString("All/Content");
-
-			try
-			{
-				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(6);
-			}
-			catch (Exception ex)
-			{
-				LogSystem.WriteLog(LogLevel.Error, ex.ToString());
-				await ReminderHelper.ShowDialog(XamlRoot, Loader.GetString("ErrorOrWarningTitle"),
-					Loader.GetString("ECanNotGetInfo"));
-			}
-			All.Visibility = WindowTracker.WindowsUsedTime.Count > 6 ? Visibility.Visible : Visibility.Collapsed;
-
 			EndUsing.SelectedTime = WindowTracker.EndUsingTime == TimeSpan.Zero ||
 				WindowTracker.EndUsingTime <= _timeNow ?
 				null : WindowTracker.EndUsingTime;
 			TimePickReminder.Text = EndUsing.SelectedTime != null &&
 				WindowTracker.EndUsingTime <= _timeNow ?
 				Loader.GetString("PastTime") : string.Empty;
+
+			try
+			{
+				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(6);
+				All.Visibility = ((List<ProcessInfo>) ProcessesList.ItemsSource).Count > 6 ?
+					Visibility.Visible : Visibility.Collapsed;
+			}
+			catch (Exception ex)
+			{
+				LogSystem.WriteLog(LogLevel.Error, ex.ToString());
+				All.Visibility = Visibility.Collapsed;
+				await ReminderHelper.ShowDialog(XamlRoot, Loader.GetString("ErrorOrWarningTitle"),
+					Loader.GetString("ECanNotGetInfo"));
+			}
+
 			LoadingRing.IsActive = false;
 		}
 
@@ -76,6 +78,7 @@ namespace Zscno.Trackora
 		{
 			LoadingRing.IsActive = true;
 			_isFirstLoad = true;
+
 			Total.Time = (TimeSpan) LocalSettings["TotalUsedRemindTime"];
 			Continuous.Time = (TimeSpan) LocalSettings["ContinuousUsedRemindTime"];
 			ResetContinuous.Time = (TimeSpan) LocalSettings["ContinuousUsedResetTime"];
@@ -91,14 +94,16 @@ namespace Zscno.Trackora
 			try
 			{
 				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(6);
+				All.Visibility = ((List<ProcessInfo>) ProcessesList.ItemsSource).Count > 6 ?
+					Visibility.Visible : Visibility.Collapsed;
 			}
 			catch (Exception ex)
 			{
 				LogSystem.WriteLog(LogLevel.Error, ex.ToString());
+				All.Visibility = Visibility.Collapsed;
 				await ReminderHelper.ShowDialog(XamlRoot, Loader.GetString("ErrorOrWarningTitle"),
 					Loader.GetString("ECanNotGetInfo"));
 			}
-			All.Visibility = WindowTracker.WindowsUsedTime.Count > 6 ? Visibility.Visible : Visibility.Collapsed;
 
 			_isFirstLoad = false;
 			LoadingRing.IsActive = false;

--- a/HomePage.xaml.cs
+++ b/HomePage.xaml.cs
@@ -38,7 +38,7 @@ namespace Zscno.Trackora
 			try
 			{
 				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(6);
-				All.Visibility = ((List<ProcessInfo>) ProcessesList.ItemsSource).Count > 6 ?
+				All.Visibility = WindowTracker.WindowsUsedTime.Count > 6 ?
 					Visibility.Visible : Visibility.Collapsed;
 			}
 			catch (Exception ex)
@@ -94,7 +94,7 @@ namespace Zscno.Trackora
 			try
 			{
 				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(6);
-				All.Visibility = ((List<ProcessInfo>) ProcessesList.ItemsSource).Count > 6 ?
+				All.Visibility = WindowTracker.WindowsUsedTime.Count > 6 ?
 					Visibility.Visible : Visibility.Collapsed;
 			}
 			catch (Exception ex)
@@ -155,8 +155,7 @@ namespace Zscno.Trackora
 
 			try
 			{
-				int count =  isRetract? 
-					6 : WindowTracker.WindowsUsedTime.Count;
+				int count =  isRetract? 6 : WindowTracker.WindowsUsedTime.Count;
 				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(count);
 			}
 			catch (Exception ex)


### PR DESCRIPTION
1. 将按钮的显示判断条件改为使用获取到的列表元素数量以适配关于不记录信息的进程的修复 (#4) 。
1. `WindowsUsedTime` 改为只读属性，获取时返回去除不记录信息进程的 `_windowsUsedTime` 。