### PR TITLE
📦构建：升级至版本 1.2.5

### DIFF
--- a/HomePage.xaml.cs
+++ b/HomePage.xaml.cs
@@ -24,29 +24,31 @@ namespace Zscno.Trackora
 
 		public async Task Refresh()
 		{
-			ProcessesList.ItemsSource = null;
 			LoadingRing.IsActive = true;
+
 			TotalUsedTime.Text = WindowTracker.GetLocalTime(WindowTracker.TotalUsedTime);
 			All.Content = Loader.GetString("All/Content");
-
-			try
-			{
-				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(6);
-			}
-			catch (Exception ex)
-			{
-				LogSystem.WriteLog(LogLevel.Error, ex.ToString());
-				await ReminderHelper.ShowDialog(XamlRoot, Loader.GetString("ErrorOrWarningTitle"),
-					Loader.GetString("ECanNotGetInfo"));
-			}
-			All.Visibility = WindowTracker.WindowsUsedTime.Count > 6 ? Visibility.Visible : Visibility.Collapsed;
-
 			EndUsing.SelectedTime = WindowTracker.EndUsingTime == TimeSpan.Zero ||
 				WindowTracker.EndUsingTime <= _timeNow ?
 				null : WindowTracker.EndUsingTime;
 			TimePickReminder.Text = EndUsing.SelectedTime != null &&
 				WindowTracker.EndUsingTime <= _timeNow ?
 				Loader.GetString("PastTime") : string.Empty;
+
+			try
+			{
+				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(6);
+				All.Visibility = WindowTracker.WindowsUsedTime.Count > 6 ?
+					Visibility.Visible : Visibility.Collapsed;
+			}
+			catch (Exception ex)
+			{
+				LogSystem.WriteLog(LogLevel.Error, ex.ToString());
+				All.Visibility = Visibility.Collapsed;
+				await ReminderHelper.ShowDialog(XamlRoot, Loader.GetString("ErrorOrWarningTitle"),
+					Loader.GetString("ECanNotGetInfo"));
+			}
+
 			LoadingRing.IsActive = false;
 		}
 
@@ -76,6 +78,7 @@ namespace Zscno.Trackora
 		{
 			LoadingRing.IsActive = true;
 			_isFirstLoad = true;
+
 			Total.Time = (TimeSpan) LocalSettings["TotalUsedRemindTime"];
 			Continuous.Time = (TimeSpan) LocalSettings["ContinuousUsedRemindTime"];
 			ResetContinuous.Time = (TimeSpan) LocalSettings["ContinuousUsedResetTime"];
@@ -91,14 +94,16 @@ namespace Zscno.Trackora
 			try
 			{
 				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(6);
+				All.Visibility = WindowTracker.WindowsUsedTime.Count > 6 ?
+					Visibility.Visible : Visibility.Collapsed;
 			}
 			catch (Exception ex)
 			{
 				LogSystem.WriteLog(LogLevel.Error, ex.ToString());
+				All.Visibility = Visibility.Collapsed;
 				await ReminderHelper.ShowDialog(XamlRoot, Loader.GetString("ErrorOrWarningTitle"),
 					Loader.GetString("ECanNotGetInfo"));
 			}
-			All.Visibility = WindowTracker.WindowsUsedTime.Count > 6 ? Visibility.Visible : Visibility.Collapsed;
 
 			_isFirstLoad = false;
 			LoadingRing.IsActive = false;
@@ -150,8 +155,7 @@ namespace Zscno.Trackora
 
 			try
 			{
-				int count =  isRetract? 
-					6 : WindowTracker.WindowsUsedTime.Count;
+				int count =  isRetract? 6 : WindowTracker.WindowsUsedTime.Count;
 				ProcessesList.ItemsSource = WindowTracker.GetProcessesInfo(count);
 			}
 			catch (Exception ex)

--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -13,7 +13,7 @@
   <Identity
     Name="33f36f29-9bae-4205-aad4-0c1d33c7350e"
     Publisher="CN=Zscno"
-    Version="1.2.4.0" />
+    Version="1.2.5.0" />
 
   <mp:PhoneIdentity PhoneProductId="33f36f29-9bae-4205-aad4-0c1d33c7350e" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -241,7 +241,7 @@
     <value>我们无法记录使用时长。详细信息请查阅日志（见 设置 页面）。</value>
   </data>
   <data name="ResetContinuousTimePicker.Header" xml:space="preserve">
-    <value>连续使用时长的重置时间</value>
+    <value>连续使用时长的重置时长</value>
   </data>
   <data name="CheckLog.Content" xml:space="preserve">
     <value>查看日志</value>

--- a/SystemHelper.cs
+++ b/SystemHelper.cs
@@ -301,7 +301,7 @@ internal class ReminderHelper
 				logError = "在发送 总使用时间提醒通知 时触发异常：";
 				title = Loader.GetString("UsedTimeReminderTitle");
 				content = Loader.GetString("TotalReminderText1") +
-					WindowTracker.GetLocalTime(WindowTracker.TotalUsedTime) +
+					WindowTracker.GetLocalTime(TimeSpan.Zero, true) +
 					Loader.GetString("TotalReminderText2");
 				audio.Src = new(CommonSounds[(string) LocalSettings["TotalUsedTimeSound"]]);
 				break;

--- a/SystemHelper.cs
+++ b/SystemHelper.cs
@@ -258,6 +258,17 @@ internal static class SystemHelper
 	}
 
 	/// <summary>
+	/// 舍入 <paramref name="value"/> 为 <see langword="uint"/> 整数。遵循一般的四舍五入规则。当 <paramref name="value"/> 的小数部分为 0.5 时，向下舍入。
+	/// </summary>
+	/// <param name="value">要操作的 <see langword="double"/> 值。</param>
+	/// <returns>舍入后的 <see langword="uint"/> 整数。</returns>
+	public static uint Round(double value)
+	{
+		uint intValue = (uint) value;
+		return (value - intValue) < 0.5 ? intValue : intValue - 1;
+	}
+
+	/// <summary>
 	/// 将创建指定窗口的线程引入前台并激活窗口。键盘输入将定向到窗口，并为用户更改各种视觉提示。
 	/// </summary>
 	/// <param name="hWnd">应激活并带到前台的窗口的句柄。</param>

--- a/WindowTracker.cs
+++ b/WindowTracker.cs
@@ -191,12 +191,6 @@ internal class WindowTracker
 		}
 		else
 		{
-			if (HasTotalReminded)
-			{
-				// 如果已经达到了今日使用时长，则每次启动都提醒。
-				CanSend = ReminderHelper.SendReminder(ReminderKinds.TotalUsedTimeReminders);
-			}
-
 			// 获取记录的使用时长。
 			_totalUsedTime = TotalUsedTime;
 			try
@@ -231,6 +225,12 @@ internal class WindowTracker
 				CanSend = ReminderHelper.SendReminder("提示用户无法获取今天的记录",
 					Loader.GetString("ErrorOrWarningTitle"),
 					Loader.GetString("ECanNotGetRecord"), true);
+			}
+
+			if (HasTotalReminded)
+			{
+				// 如果已经达到了今日使用时长，则每次启动都提醒。
+				CanSend = ReminderHelper.SendReminder(ReminderKinds.TotalUsedTimeReminders);
 			}
 		}
 

--- a/WindowTracker.cs
+++ b/WindowTracker.cs
@@ -585,90 +585,97 @@ internal class WindowTracker
 					goto Finish;
 				}
 
-				IReadOnlyList<AppListEntry> appListEntries = await package.GetAppListEntriesAsync();
-				AppListEntry appListEntry = appListEntries.Count > 0 ? appListEntries[0] : null;
-				if (appListEntries == null)
-				{
-					WriteLog(LogLevel.Warning, $"出于未知原因，未获取到包 {name} 的显示信息。");
-					info = GetDefaultInfo(process);
-					goto Finish;
-				}
-
-				AppDisplayInfo displayinfo = appListEntry.DisplayInfo;
-				RandomAccessStreamReference iconStreamRef = displayinfo.GetLogo(new(32, 32));
-				if (iconStreamRef == null)
-				{
-					WriteLog(LogLevel.Warning, $"出于未知原因，未获取到包 {name} 的图标。");
-					info = GetDefaultInfo(process);
-					goto Finish;
-				}
-
 				// 加载图标并将图标保存到缓存文件夹中。
 				string iconUri;
 				try
 				{
-					IRandomAccessStreamWithContentType iconStream = await iconStreamRef.OpenReadAsync();
+					string iconPath = package.Logo.LocalPath;
+					StorageFile iconFile1 = await StorageFile.GetFileFromPathAsync(iconPath);
+					IRandomAccessStreamWithContentType iconStream = await iconFile1.OpenReadAsync();
 
 					// 获取图标的实际内容范围。
 					BitmapDecoder decoder = await BitmapDecoder.CreateAsync(iconStream);
 					PixelDataProvider pixelData = await decoder.GetPixelDataAsync();
 					byte[] pixels = pixelData.DetachPixelData();
 					uint width = decoder.PixelWidth, height = decoder.PixelHeight;
-					uint x = 0, y = 0, w = 0, h = 0;
-					for (uint i = 0; i < height; i++)
+					uint minX = 0, minY = 0, maxX = 0, maxY = 0;
+					bool exit;
+
+					// 从左向右遍历每一列，找到最左边有内容的像素列。
+					exit = false;
+					for (uint column = 0; column < width && !exit; column++)
 					{
-						for (uint j = 0; j < width; j++)
+						for (uint pixel = 0; pixel < height && !exit; pixel++)
 						{
-							if (pixels[(i * width + j) * 4 + 3] >= 20)
+							if (pixels[(pixel * width + column) * 4 + 3] > 0)
 							{
-								if (x == 0 || i < x)
-								{
-									x = i;
-								}
-								if (y == 0 || j < y)
-								{
-									y = j;
-								}
-								if (w == 0 || i > w)
-								{
-									w = i;
-								}
-								if (h == 0 || j > h)
-								{
-									h = j;
-								}
+								minX = column;
+								exit = true;
 							}
 						}
 					}
 
-					// 图标实际内容的宽和高至少为 32 像素且必须是正方形。
-					uint cropWidth = w - x + 1, cropHeight = h - y + 1;
-					if (cropWidth < 32 || cropHeight < 32)
+					// 从右向左遍历每一列，找到最右边有内容的像素列。
+					exit = false;
+					for (uint column = width - 1; column >= 0 && !exit; column--)
+					{
+						for (uint pixel = 0; pixel < height && !exit; pixel++)
+						{
+							if (pixels[(pixel * width + column) * 4 + 3] > 0)
+							{
+								maxX = column;
+								exit = true;
+							}
+						}
+					}
+
+					// 从上向下遍历每一行，找到最上边有内容的像素行。
+					exit = false;
+					for (uint row = 0; row < height && !exit; row++)
+					{
+						for (uint pixel = minX; pixel <= maxX && !exit; pixel++)
+						{
+							if (pixels[(row * width + pixel) * 4 + 3] > 0)
+							{
+								minY = row;
+								exit = true;
+							}
+						}
+					}
+
+					// 从下向上遍历每一行，找到最下边有内容的像素行。
+					exit = false;
+					for (uint row = height - 1; row >= 0 && !exit; row--)
+					{
+						for (uint pixel = minX; pixel <= maxX && !exit; pixel++)
+						{
+							if (pixels[(row * width + pixel) * 4 + 3] > 0)
+							{
+								maxY = row;
+								exit = true;
+							}
+						}
+					}
+
+					uint cropWidth = maxX - minX + 1, cropHeight = maxY - minY + 1;
+
+					// 图标裁剪区域至少为 32 * 32 像素，且裁剪区域坐标不能为负。
+					if (cropWidth < 32 && cropHeight < 32)
 					{
 						cropWidth = cropHeight = 32;
-						x = (width - cropWidth) / 2;
-						y = (height - cropHeight) / 2;
+						minX = SystemHelper.Round((width - cropWidth) / 2);
+						minY = SystemHelper.Round((width - cropHeight) / 2);
 					}
-					else if (cropWidth > cropHeight)
-					{
-						cropHeight = cropWidth;
-						y = (height - cropHeight) / 2;
-					}
-					else if (cropHeight > cropWidth)
-					{
-						cropWidth = cropHeight;
-						x = (width - cropWidth) / 2;
-					}
-					x = x < 0 ? 0 : x;
-					y = y < 0 ? 0 : y;
+					minX = minX < 0 ? 0 : minX;
+					minY = minY < 0 ? 0 : minY;
 
 					//裁剪图标。
 					InMemoryRandomAccessStream croppedStream = new();
 					BitmapEncoder encoder = await BitmapEncoder.CreateForTranscodingAsync(croppedStream, decoder);
 					encoder.BitmapTransform.Bounds = new()
 					{
-						X = x,
-						Y = y,
+						X = minX,
+						Y = minY,
 						Width = cropWidth,
 						Height = cropHeight,
 					};

--- a/Zscno.Trackora.csproj
+++ b/Zscno.Trackora.csproj
@@ -25,9 +25,6 @@
     <PackageCertificateKeyFile>Zscno.Trackora_TemporaryKey.pfx</PackageCertificateKeyFile>
     <AppxPackageDir>D:\Code\Zscno.Trackora\Publish\</AppxPackageDir>
   </PropertyGroup>
-  <ItemGroup>
-    <None Remove="SettingsPage.xaml" />
-  </ItemGroup>
 	
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
@@ -88,15 +85,18 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
 		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+		<ApplicationManifest>app.publish.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
 		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+		<ApplicationManifest>app.publish.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm64'">
 		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
 		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+		<ApplicationManifest>app.publish.manifest</ApplicationManifest>
 	</PropertyGroup>
 	
   <!-- 

--- a/app.manifest
+++ b/app.manifest
@@ -17,11 +17,11 @@
 	</windowsSettings>
   </application>
 
-	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+	<!--<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>
 			<requestedPrivileges>
 				<requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
 			</requestedPrivileges>
 		</security>
-	</trustInfo>
+	</trustInfo>-->
 </assembly>

--- a/app.manifest
+++ b/app.manifest
@@ -1,27 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="Zscno.Trackora.app"/>
+	<assemblyIdentity version="1.0.0.0" name="Zscno.Trackora.app"/>
 
-  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-	<application>
-	  <!-- The ID below informs the system that this application is compatible with OS features first introduced in Windows 10. 
-	  It is necessary to support features in unpackaged applications, for example the custom titlebar implementation.
-	  For more info see https://docs.microsoft.com/windows/apps/windows-app-sdk/use-windows-app-sdk-run-time#declare-os-compatibility-in-your-application-manifest -->
-	  <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<!-- 设计此应用程序与其一起工作且已针对此应用程序进行测试的
+			Windows 版本的列表。取消评论适当的元素，Windows 将自动选择最兼容的环境。 -->
+
+			<!-- Windows Vista -->
+			<!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+			<!-- Windows 7 -->
+			<!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+			<!-- Windows 8 -->
+			<!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+			<!-- Windows 8.1 -->
+			<!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+			<!-- Windows 10 -->
+			<!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+		</application>
+	</compatibility>
+
+	<application xmlns="urn:schemas-microsoft-com:asm.v3">
+		<windowsSettings>
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+		</windowsSettings>
 	</application>
-  </compatibility>
-  
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-	<windowsSettings>
-	  <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-	</windowsSettings>
-  </application>
 
-	<!--<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
 		<security>
-			<requestedPrivileges>
-				<requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+			<requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+				<!-- UAC 清单选项
+				如果想要更改 Windows 用户帐户控制级别，请使用
+				以下节点之一替换 requestedExecutionLevel 节点。
+
+				<requestedExecutionLevel  level="asInvoker" uiAccess="false"/>
+				<requestedExecutionLevel  level="requireAdministrator" uiAccess="false"/>
+				<requestedExecutionLevel  level="highestAvailable" uiAccess="false"/>
+
+				指定 requestedExecutionLevel 元素将禁用文件和注册表虚拟化。
+				如果你的应用程序需要此虚拟化来实现向后兼容性，则移除此元素。
+				-->
+				<requestedExecutionLevel  level="asInvoker" uiAccess="false"/>
 			</requestedPrivileges>
 		</security>
-	</trustInfo>-->
+	</trustInfo>
+	
+	<!-- 指示该应用程序可感知 DPI 且 Windows 在 DPI 较高时将不会对其进行
+	自动缩放。Windows Presentation Foundation (WPF)应用程序自动感知 DPI，无需
+	选择加入。选择加入此设置的 Windows 窗体应用程序(面向 .NET Framework 4.6)还应
+	在其 app.config 中将 "EnableWindowsFormsHighDpiAutoResizing" 设置设置为 "true"。
+	   
+	将应用程序设为感知长路径。请参阅 https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+	<!--
+	<application xmlns="urn:schemas-microsoft-com:asm.v3">
+		<windowsSettings>
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+			<longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+		</windowsSettings>
+	</application>
+	-->
+
+	<!-- 启用 Windows 公共控件和对话框的主题(Windows XP 和更高版本) -->
+	<!--
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity
+				type="win32"
+				name="Microsoft.Windows.Common-Controls"
+				version="6.0.0.0"
+				processorArchitecture="*"
+				publicKeyToken="6595b64144ccf1df"
+				language="*"
+			/>
+		</dependentAssembly>
+	</dependency>
+	-->
 </assembly>

--- a/app.publish.manifest
+++ b/app.publish.manifest
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Zscno.Trackora.app"/>
+
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+      <windowsSettings>
+          <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      </windowsSettings>
+    </application>
+
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
# 更新内容

## 修复

- 主页中总使用时长与所有应用使用时长有非预期的较大的误差 (#1)
- 启动时发出的“总使用时长提醒”显示使用 <1 分 (#2)
- 主页中某些应用的图标显示异常 (#3)
- 不记录信息的进程不能正常记录其使用时长 (#4)
- “查看所有应用”按钮没有正确显示 (#5)
- 更正了某些表达