### PR TITLE
🔧修复：Json 反射序列化及反序列化被禁用

### DIFF
--- a/Trackora/SystemHelper.cs
+++ b/Trackora/SystemHelper.cs
@@ -2,9 +2,11 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using WinRT.Interop;
 using static Zscno.Trackora.App;
@@ -474,4 +476,13 @@ internal enum ReminderKinds
 	/// 结束使用时间提醒提示音的测试通知。
 	/// </summary>
 	EndUsingTimeSoundTest,
+}
+
+/// <summary>
+/// 提供有关与 JSON 序列化相关的一组类型的元数据。
+/// </summary>
+[JsonSerializable(typeof(List<ProcessInfo>))]
+internal partial class JsonSerializeMetadata : JsonSerializerContext
+{
+	
 }

--- a/Trackora/Trackora.csproj
+++ b/Trackora/Trackora.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Zscno.Trackora</RootNamespace>
-    <ApplicationManifest>app.publish.manifest</ApplicationManifest>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>

--- a/Trackora/WindowTracker.cs
+++ b/Trackora/WindowTracker.cs
@@ -336,7 +336,8 @@ internal class WindowTracker
 		{
 			try
 			{
-				List<ProcessInfo> list = JsonSerializer.Deserialize<List<ProcessInfo>>(processesListText);
+				List<ProcessInfo> list = JsonSerializer.Deserialize(processesListText, 
+					JsonSerializeMetadata.Default.ListProcessInfo);
 				Dictionary<string, ProcessInfo> dict = list.ToDictionary(value => value.ProcessName);
 				return dict;
 			}
@@ -470,7 +471,7 @@ internal class WindowTracker
 			using FileStream textStream = new(InfoFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
 			// 如果文件中有内容则反序列化，如果结果为 null 或没有内容则创建新列表。
 			processesInfo = textStream.Length > 0 ?
-				JsonSerializer.Deserialize<List<ProcessInfo>>(textStream) ?? new() : new();
+				JsonSerializer.Deserialize(textStream, JsonSerializeMetadata.Default.ListProcessInfo) ?? new() : new();
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
改用源生成进行 Json 序列化及反序列化以代替反射序列化及反序列化。