### PR TITLE
🔧修复：不能记录使用时长

### DIFF
--- a/Trackora/NativeApi.cs
+++ b/Trackora/NativeApi.cs
@@ -109,7 +109,7 @@ namespace Zscno.Trackora
 		/// <param name="lpszClass">指定窗口类名。</param>
 		/// <param name="lpszWindow">窗口名称（窗口的标题）。</param>
 		/// <returns>如果函数成功，则返回值是具有指定类和窗口名称的窗口的句柄。如果函数失败，则返回值 <see langword="null"/>。</returns>
-		[LibraryImport("user32.dll", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		[LibraryImport("user32.dll", EntryPoint = "FindWindowExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
 		public static partial nint FindWindowEx(
 			nint hWndParent,
 			nint hWndChildAfter,

--- a/Trackora/WindowTracker.cs
+++ b/Trackora/WindowTracker.cs
@@ -1078,6 +1078,7 @@ namespace Zscno.Trackora
                 !TryGetProcessById((int)processId, out Process process,
                     $"获取进程 [ID={processId}] 的信息失败。"))
             {
+                NoProcessNow();
                 return;
             }
 
@@ -1092,9 +1093,16 @@ namespace Zscno.Trackora
             (bool shouldKeepRecording, Process? p) = GetRealProcess(name, handle);
             if (!shouldKeepRecording)
             {
+                NoProcessNow();
                 return;
             }
             process = p ?? process;
+
+            if (name == _lastProcess?.ProcessName)
+            {
+                return;
+            }
+
             UpdateUsageTime();
             _ = new SafeCaller() { RemindingMsgResKey = "ECanNotRecordTime" }
             .CallMethodR(() => RecordUsageTime(name));

--- a/Trackora/WindowTracker.cs
+++ b/Trackora/WindowTracker.cs
@@ -741,7 +741,7 @@ namespace Zscno.Trackora
             {
                 "explorer" => (CheckExplorerProcess(handle), null),
                 "ApplicationFrameHost" => GetRealUwpProcess(handle),
-                _ => (false, null),
+                _ => (true, null),
             };
         }
 

--- a/Trackora/WindowTracker.cs
+++ b/Trackora/WindowTracker.cs
@@ -566,7 +566,7 @@ namespace Zscno.Trackora
             }
 
             return (GetIconForWin32(name, path),
-                GetDisplayName(process.ProcessName, process.MainWindowTitle));
+                GetDisplayName(process.ProcessName, process.MainWindowTitle, mainModule.FileVersionInfo.FileDescription));
         }
 
         /// <summary>


### PR DESCRIPTION
# 🔧修复的内容
- 不能准确显示使用时长

    - 当获取活动进程失败或活动进程为桌面、任务栏或无窗口的 UWP 进程时，未能按无活动进程情况处理，

    - 当活动进程重复时没有忽略；
- 不获取 Win32 进程友好名称；
- 无法记录非 Explorer 或 UWP 进程；
- 未指定 FindWindowEx 函数入口点。